### PR TITLE
Don't use column name as parameter when calling nullableTimestamps()

### DIFF
--- a/src/GenerateMigrations.php
+++ b/src/GenerateMigrations.php
@@ -344,11 +344,11 @@ class GenerateMigrations extends Command
         foreach ($results as $columnName => &$columnAttr) {
 
             if (in_array($columnAttr['type'], [
-                'timestamps', 'rememberToken', 'softDeletes'
+                'timestamps', 'rememberToken', 'softDeletes', 'nullableTimestamps',
             ])) {
                 $columnAttr['command'] = sprintf('$table->%s();', $columnAttr['type']);
             } elseif (in_array($columnAttr['type'], [
-                'morphs', 'nullableMorphs', 'nullableTimestamps',
+                'morphs', 'nullableMorphs',
                 'bigIncrements', 'increments', 'smallIncrements',
             ])) {
                 $columnAttr['command'] = sprintf('$table->%s(\'%s\');', $columnAttr['type'], $columnAttr['name']);


### PR DESCRIPTION
nullableTimestamps() method of Blueprint class uses first (and only) parameter to set the column precision. Since it's an alias for timestamps() method, we might handle both cases the same way.

Right now, migrations are being generated like this: `$table->nullableTimestamps('created_at');`
This raises an error when running `php artisan migrate` command.

```
Doctrine\DBAL\Driver\PDOException::("SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'created_at) null, `updated_at` timestamp(created_at) null, `name` varchar(191) n' at line 1")
```

This PR solves the situation by removing the method parameter when generating the migration file.